### PR TITLE
Puppeteer - Adding missing waitForXPath method

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -900,6 +900,11 @@ export interface FrameBase {
     selector: string,
     options?: { visible?: boolean; hidden?: boolean; timeout?: number }
   ): Promise<ElementHandle>;
+  
+  waitForXPath(
+    xpath: string,
+    options?: { visible?: boolean; hidden?: boolean; timeout?: number }
+  ): Promise<ElementHandle>;
 }
 
 export interface Frame extends FrameBase {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagewaitforxpathxpath-options>>
- [ ] Increase the version number in the header if appropriate.
Puppeteer has waitForXPath method since 1.1.0. Not sure how to put it on older versions of the `@type`.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
